### PR TITLE
Fix: unicode chars in video title causes error

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ class VideoLink:
         for link in soup.findAll("a", href=re.compile("^magnet")):
             magnetUrl = link.get("href")
             if magnetUrl.startswith("magnet:?"):
-                xbmc.log(title,xbmc.LOGERROR)
+                xbmc.log(title.encode('utf-8'),xbmc.LOGERROR)
                 return {'magnetUrl':magnetUrl,'title':title , 'poster':poster , 'artist':artist}
         raise ValueError("Could not find the magnet link for this video.")
 
@@ -609,7 +609,7 @@ def playVideo(videoId):
 
 def playWithCustomPlayer(url, webTorrentClient,videoInfo={'magnetUrl':""},seed_after=False):
     play_item = xbmcgui.ListItem(path=url)
-    xbmc.log(videoInfo['title'],xbmc.LOGERROR)
+    xbmc.log(videoInfo['title'].encode('utf-8'),xbmc.LOGERROR)
     try:
         play_item.setInfo("video",{'title':videoInfo['title'] , 'artist':[videoInfo['artist']]})
         play_item.setArt({'poster':videoInfo['poster']})


### PR DESCRIPTION
Adresses following error which often occurs on german videos using non ascii characters in video titles.

> 2019-07-22 13:51:53.962 T:21107   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
>                                              - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
>                                             Error Type: <type 'exceptions.UnicodeEncodeError'>
>                                             Error Contents: 'ascii' codec can't encode character u'\xfc' in position 22: ordinal not in range(128)
>                                             Traceback (most recent call last):
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.bitchute/main.py", line 688, in <module>
>                                                 router(sys.argv[2][1:])
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.bitchute/main.py", line 671, in router
>                                                 playVideo(params['videoId'])
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.bitchute/main.py", line 566, in playVideo
>                                                 videoInfo = VideoLink.getInfo(videoId)
>                                               File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.bitchute/main.py", line 65, in getInfo
>                                                 xbmc.log(title,xbmc.LOGERROR)
>                                             UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 22: ordinal not in range(128)
>                                             -->End of Python script error report<--